### PR TITLE
Add Claude PR assistance integration

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,30 @@
+name: Claude Assistant
+on:
+  issue_comment:
+    types: [ created ]
+  pull_request_review_comment:
+    types: [ created ]
+  issues:
+    types: [ opened, assigned ]
+  pull_request_review:
+    types: [ submitted ]
+
+jobs:
+  claude-response:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: anthropics/claude-code-action@beta
+      with:
+        anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+        github_token: ${{ secrets.GITHUB_PERSONAL_ACCESS_TOKEN }}
+        # Optional: add custom trigger phrase (default: @claude)
+        # trigger_phrase: "/claude"
+        # Optional: add assignee trigger for issues
+        # assignee_trigger: "claude"
+        # Optional: add custom environment variables (YAML format)
+        # claude_env: |
+        #   NODE_ENV: test
+        #   DEBUG: true
+        #   API_URL: https://api.example.com
+        # Optional: limit the number of conversation turns
+        # max_turns: "5"


### PR DESCRIPTION
## Summary
- Add Claude GitHub Actions workflow to enable AI-powered PR assistance
- Supports @claude mentions in PR comments for automated AI code review and assistance

## Features
- Responds to @claude mentions in PR comments and issue comments
- Integrates with Anthropic's Claude Code Action for automated responses
- Supports PR review comments and issue assignments
- Configurable trigger phrases and environment variables

## Requirements
- Requires `ANTHROPIC_API_KEY` secret to be configured in repository settings
- Requires `GITHUB_PERSONAL_ACCESS_TOKEN` secret for GitHub API access

## Test plan
- [x] Create GitHub Actions workflow file
- [ ] Configure required secrets in repository settings
- [ ] Test @claude mentions in PR comments
- [ ] Verify automated responses work correctly

🤖 Generated with [Claude Code](https://claude.ai/code)